### PR TITLE
cwh-repo2docker: Switch from c.JupyterHub.extra_handlers to services

### DIFF
--- a/jupyterhub/Dockerfile
+++ b/jupyterhub/Dockerfile
@@ -64,6 +64,7 @@ RUN python3 -m pip install --no-cache /tmp/wheelhouse/*
 # Resources
 RUN mkdir /var/jupyterhub
 ADD jupyterhub_config.py /srv/jupyterhub/
+ADD cwh_repo2docker_config.py /srv/jupyterhub/
 ADD resources-schema.json /srv/jupyterhub/
 ADD get_user_id.sh /
 RUN chmod +x /get_user_id.sh

--- a/jupyterhub/cwh-repo2docker/MANIFEST.in
+++ b/jupyterhub/cwh-repo2docker/MANIFEST.in
@@ -1,2 +1,3 @@
+recursive-include cwh_repo2docker/custom_templates/ *
 recursive-include cwh_repo2docker/templates/ *
 recursive-include cwh_repo2docker/static/ *

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/__init__.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/__init__.py
@@ -171,7 +171,8 @@ def cwh_repo2docker_jupyterhub_config(
         c,
         config_file=None,
         service_name='environments',
-        custom_menu=False):
+        custom_menu=False,
+        debug=False):
     # hub
     c.JupyterHub.spawner_class = Repo2DockerSpawner
 
@@ -191,6 +192,11 @@ def cwh_repo2docker_jupyterhub_config(
     if config_file is not None:
         service_command.extend([
             "--config-file", config_file
+        ])
+
+    if debug:
+        service_command.extend([
+            "--debug"
         ])
 
     environ_names = [

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/__init__.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/__init__.py
@@ -172,6 +172,7 @@ def cwh_repo2docker_jupyterhub_config(
         config_file=None,
         service_name='environments',
         custom_menu=False,
+        service_environments={},
         debug=False):
     # hub
     c.JupyterHub.spawner_class = Repo2DockerSpawner
@@ -199,18 +200,6 @@ def cwh_repo2docker_jupyterhub_config(
             "--debug"
         ])
 
-    environ_names = [
-        'CONTAINER_IMAGE',
-        'REGISTRY_HOST',
-        'REGISTRY_USER',
-        'REGISTRY_PASSWORD'
-    ]
-
-    environments = {}
-    for name in environ_names:
-        if name in os.environ:
-            environments[name] = os.environ[name]
-
     c.JupyterHub.template_vars.update({
         'cwh_repo2docker_service_name': service_name
     })
@@ -221,6 +210,6 @@ def cwh_repo2docker_jupyterhub_config(
         "url": "http://127.0.0.1:10101",
         "display": not custom_menu,
         "oauth_no_confirm": True,
-        "environment": environments,
+        "environment": service_environments,
         "oauth_client_allowed_scopes": ["inherit"]
     }])

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/base.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/base.py
@@ -28,6 +28,7 @@ class BaseHandler(web.RequestHandler):
                 self.settings['hub_prefix']),
             prefix=self.settings['base_url'],
             service_prefix=self.settings['service_prefix'],
+            brand_text=self.settings['brand_text'],
             user=user,
             static_url=self.static_url,
             no_spawner_check=True

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/base.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/base.py
@@ -1,0 +1,48 @@
+import json
+
+from tornado import web
+from tornado.log import app_log
+
+from jupyterhub.utils import url_path_join
+
+
+class BaseHandler(web.RequestHandler):
+    @property
+    def log(self):
+        return self.settings.get('log', app_log)
+
+    def render_template(self, name, **ns):
+        template_ns = {}
+        template_ns.update(self.template_namespace)
+        template_ns["xsrf_token"] = self.xsrf_token.decode("ascii")
+        template_ns.update(ns)
+        template = self.settings['jinja2_env'].get_template(name)
+        return template.render_async(**template_ns)
+
+    @property
+    def template_namespace(self):
+        user = self.current_user
+        ns = dict(
+            base_url=url_path_join(
+                self.settings['base_url'],
+                self.settings['hub_prefix']),
+            prefix=self.settings['base_url'],
+            service_prefix=self.settings['service_prefix'],
+            user=user,
+            static_url=self.static_url,
+            no_spawner_check=True
+        )
+        return ns
+
+    def get_json_body(self):
+        """Return the body of the request as JSON data."""
+        if not self.request.body:
+            return None
+        body = self.request.body.strip().decode('utf-8')
+        try:
+            model = json.loads(body)
+        except Exception:
+            self.log.debug("Bad JSON: %r", body)
+            self.log.error("Couldn't parse JSON", exc_info=True)
+            raise web.HTTPError(400, 'Invalid JSON in body of request')
+        return model

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/custom_templates/page.html
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/custom_templates/page.html
@@ -1,0 +1,8 @@
+{% extends "templates/page.html" %}
+
+{% block nav_bar_left_items %}
+{{ super() }}
+{% if 'access:services!service={{cwh_repo2docker_service_name}}' in expanded_scopes or 'access:services' in expanded_scopes %}
+<li><a href="{{prefix}}services/{{cwh_repo2docker_service_name}}/">Environments</a></li>
+{% endif %}
+{% endblock %}

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/images.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/images.py
@@ -1,20 +1,17 @@
-from inspect import isawaitable
-from jupyterhub.handlers.base import BaseHandler
-from jupyterhub.scopes import needs_scope
+from jupyterhub.services.auth import HubOAuthenticated
 from tornado import web
-import json
 
 from .docker import list_containers
 from .registry import get_registry
+from .base import BaseHandler
 
 
-class ImagesHandler(BaseHandler):
+class ImagesHandler(HubOAuthenticated, BaseHandler):
     """
     Handler to show the list of environments as Docker images
     """
 
     @web.authenticated
-    @needs_scope('admin-ui')
     async def get(self):
         registry = get_registry(config=self.settings['config'])
         images = await registry.list_images()
@@ -23,7 +20,4 @@ class ImagesHandler(BaseHandler):
             "images.html",
             images=images + containers
         )
-        if isawaitable(result):
-            self.write(await result)
-        else:
-            self.write(result)
+        self.write(await result)

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/logs.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/logs.py
@@ -1,18 +1,18 @@
 import json
 
 from aiodocker import Docker
-from jupyterhub.apihandlers import APIHandler
-from jupyterhub.utils import admin_only
+from jupyterhub.services.auth import HubOAuthenticated
 from tornado import web
 from tornado.iostream import StreamClosedError
 
+from .base import BaseHandler
 
-class LogsHandler(APIHandler):
+
+class LogsHandler(HubOAuthenticated, BaseHandler):
     """
     Expose a handler to follow the build logs.
     """
     @web.authenticated
-    @admin_only
     async def get(self, name):
         self.set_header("Content-Type", "text/event-stream")
         self.set_header("Cache-Control", "no-cache")

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/service.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/service.py
@@ -27,6 +27,11 @@ class CwhRepo2DockerApplication(Application):
         help="The config file to load").tag(
         config=True
     )
+    brand_text = Unicode(
+        'Environments',
+        help='Brand text in navigation header').tag(
+        config=True
+    )
     aliases = {
         "config-file": "CwhRepo2DockerApplication.config_file"
     }
@@ -72,6 +77,7 @@ class CwhRepo2DockerApplication(Application):
             'app': self,
             'log': self.log,
             'base_url': base_url,
+            'brand_text': self.brand_text,
             'jinja2_env': jinja_env,
             'static_path': jupyterhub_static_path,
             'static_url_prefix': url_path_join(base_url, 'static/'),

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/service.py
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/service.py
@@ -1,0 +1,150 @@
+import os
+from urllib.parse import urlparse
+
+from tornado import web
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
+
+from traitlets import Unicode
+from traitlets.config import Application, catch_config_error
+
+from jupyterhub.services.auth import HubOAuthCallbackHandler
+from jupyterhub.utils import url_path_join
+from jupyterhub.traitlets import URLPrefix
+from jupyterhub._data import DATA_FILES_PATH
+
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
+
+from .builder import BuildHandler, DefaultCourseImageHandler
+from .images import ImagesHandler
+from .logs import LogsHandler
+
+
+class CwhRepo2DockerApplication(Application):
+
+    config_file = Unicode(
+        '/srv/jupyterhub/cwh_repo2docker_config.py',
+        help="The config file to load").tag(
+        config=True
+    )
+    aliases = {
+        "config-file": "CwhRepo2DockerApplication.config_file"
+    }
+
+    hub_prefix = URLPrefix('/hub/')
+
+    @catch_config_error
+    async def initialize(self, *args, **kwargs):
+        super().initialize(*args, **kwargs)
+
+        self.load_config_file(self.config_file)
+
+    async def start(self):
+        self.io_loop = IOLoop.current()
+
+        base_url = os.environ['JUPYTERHUB_BASE_URL']
+        service_prefix = os.environ['JUPYTERHUB_SERVICE_PREFIX']
+        oauth_callback_url = os.environ.get(
+            'JUPYTERHUB_OAUTH_CALLBACK_URL',
+            url_path_join(service_prefix, 'oauth_callback'))
+
+        jupyterhub_template_path = os.path.join(DATA_FILES_PATH, 'templates')
+        template_path = os.path.join(os.path.dirname(__file__), "templates")
+        jupyterhub_static_path = os.path.join(DATA_FILES_PATH, 'static')
+        static_path = os.path.join(os.path.dirname(__file__), "static")
+
+        template_paths = [
+            template_path,
+            jupyterhub_template_path,
+        ]
+
+        jinja_options = dict(autoescape=True, enable_async=True)
+        loader = ChoiceLoader(
+            [
+                PrefixLoader({'templates': FileSystemLoader([jupyterhub_template_path])}, '/'),
+                FileSystemLoader(template_paths),
+            ]
+        )
+        jinja_env = Environment(loader=loader, **jinja_options)
+
+        self.tornado_settings = {
+            'config': self.config,
+            'app': self,
+            'log': self.log,
+            'base_url': base_url,
+            'jinja2_env': jinja_env,
+            'static_path': jupyterhub_static_path,
+            'static_url_prefix': url_path_join(base_url, 'static/'),
+            'service_prefix': service_prefix,
+            'hub_prefix': self.hub_prefix,
+            'xsrf_cookies': True,
+            'xsrf_cookie_kwargs': {
+                'path': url_path_join(base_url, service_prefix)
+            },
+            'cookie_secret': os.urandom(32),
+        }
+
+        self.tornado_application = web.Application(
+            [
+                (service_prefix, ImagesHandler),
+                (oauth_callback_url, HubOAuthCallbackHandler),
+                (url_path_join(service_prefix, 'api/environments'),
+                    BuildHandler),
+                (url_path_join(
+                    service_prefix, 'api/environments/default-course-image'),
+                    DefaultCourseImageHandler),
+                (url_path_join(
+                    service_prefix, r'api/environments/([^/]+)/logs'),
+                    LogsHandler),
+                (url_path_join(service_prefix, r"static/(.*)"),
+                    web.StaticFileHandler,
+                    {
+                        "path": static_path
+                    }
+                 )
+            ],
+            **self.tornado_settings
+        )
+
+        self.http_server = HTTPServer(self.tornado_application)
+
+        url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
+        self.http_server.listen(url.port, url.hostname)
+
+    def stop(self):
+        if not self.io_loop:
+            return
+        if self.http_server:
+            self.http_server.stop()
+
+    async def launch_instance_async(self, argv=None):
+        try:
+            await self.initialize(argv)
+            await self.start()
+        except Exception as e:
+            self.log.exception("")
+            self.exit(1)
+
+
+def main():
+    app = CwhRepo2DockerApplication()
+
+    loop = IOLoop(make_current=False)
+
+    try:
+        loop.run_sync(app.launch_instance_async)
+    except Exception:
+        loop.close()
+        raise
+
+    try:
+        loop.start()
+    except KeyboardInterrupt:
+        print("\nInterrupted")
+    finally:
+        loop.stop()
+        loop.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/static/js/images.js
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/static/js/images.js
@@ -1,7 +1,7 @@
 require([
   "jquery", "bootstrap", "moment", "jhapi", "utils",
-  "environments-static/vendor/xterm-addon-fit.js",
-  "environments-static/vendor/xterm.js"
+  "static/vendor/xterm-addon-fit.js",
+  "static/vendor/xterm.js"
 ], function(
   $,
   bs,
@@ -14,8 +14,8 @@ require([
   "use strict";
 
   var base_url = window.jhdata.base_url;
+  var xsrf_token = window.jhdata.xsrf_token || window.xsrf_token;
   var api = new JHAPI(base_url);
-
 
   function getRow(element) {
     var original = element;
@@ -47,7 +47,7 @@ require([
     var row = getRow(el);
     var name = row.data('image');
     var digest = row.data('manifest-digest');
-    api.api_request("environments/default-course-image", {
+    $.ajax("api/environments/default-course-image?_xsrf=" + xsrf_token, {
       type: "PUT",
       data: JSON.stringify({
         name: name,
@@ -72,7 +72,7 @@ require([
       var spinner = $("#adding-environment-dialog");
       spinner.find('.modal-footer').remove();
       spinner.modal();
-      api.api_request("environments", {
+      $.ajax("api/environments?_xsrf=" + xsrf_token, {
         type: "POST",
         data: JSON.stringify({
           repo: repo,
@@ -107,7 +107,7 @@ require([
       var spinner = $("#removing-environment-dialog");
       spinner.find('.modal-footer').remove();
       spinner.modal();
-      api.api_request("environments", {
+      $.ajax("api/environments?_xsrf=" + xsrf_token, {
         type: "DELETE",
         data: JSON.stringify({
           name: image
@@ -140,7 +140,8 @@ require([
       log.open(container);
       fitAddon.fit();
 
-      var logsUrl = utils.url_path_join(base_url, "api", "environments", image, "logs");
+      var logsUrl = utils.url_path_join("api", "environments", image, "logs");
+      logsUrl += "?_xsrf=" + xsrf_token;
       eventSource = new EventSource(logsUrl);
       eventSource.onerror = function(err) {
         console.error("Failed to construct event stream", err);

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/templates/images.html
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/templates/images.html
@@ -2,8 +2,8 @@
 
 {% block stylesheet %}
 {{ super() }}
-<link rel="stylesheet" href="{{ base_url }}environments-static/css/style.css" type="text/css"/>
-<link rel="stylesheet" href="{{ base_url }}environments-static/vendor/xterm.css" type="text/css"/>
+<link rel="stylesheet" href="static/css/style.css" type="text/css"/>
+<link rel="stylesheet" href="static/vendor/xterm.css" type="text/css"/>
 {% endblock %}
 
 {% block main %}
@@ -164,6 +164,7 @@
 {% block script %}
 {{ super() }}
 <script type="text/javascript">
-require(["{{ base_url }}environments-static/js/images.js"]);
+window.xsrf_token = "{{ xsrf_token }}";
+require(["static/js/images.js"]);
 </script>
 {% endblock %}

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/templates/page.html
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/templates/page.html
@@ -7,6 +7,7 @@
         <span id="jupyterhub-logo" class="pull-left">
             <a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub logo' class='jpy-logo' title='Home'/></a>
         </span>
+        <span class="navbar-brand">{{ brand_text }}</span>
       </div>
       <div class="collapse navbar-collapse" id="thenavbar">
         <ul class="nav navbar-nav">

--- a/jupyterhub/cwh-repo2docker/cwh_repo2docker/templates/page.html
+++ b/jupyterhub/cwh-repo2docker/cwh_repo2docker/templates/page.html
@@ -1,8 +1,21 @@
 {% extends "templates/page.html" %}
 
-{% block nav_bar_left_items %}
-{{ super() }}
-{% if 'admin-ui' in parsed_scopes %}
-<li><a href="{{base_url}}environments">Environments</a></li>
-{% endif %}
+{% block nav_bar %}
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <div class="navbar-header">
+        <span id="jupyterhub-logo" class="pull-left">
+            <a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub logo' class='jpy-logo' title='Home'/></a>
+        </span>
+      </div>
+      <div class="collapse navbar-collapse" id="thenavbar">
+        <ul class="nav navbar-nav">
+            <li><a href="{{base_url}}home">Home</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+{% endblock %}
+
+{% block announcement %}
 {% endblock %}

--- a/jupyterhub/cwh_repo2docker_config.py
+++ b/jupyterhub/cwh_repo2docker_config.py
@@ -1,0 +1,11 @@
+import os
+
+registry_host = os.environ['REGISTRY_HOST']
+initial_image = os.environ.get('CONTAINER_IMAGE', 'coursewarehub/initial-course-image:latest')
+
+c.Registry.initial_course_image = initial_image
+c.Registry.default_course_image = os.environ.get('CONTAINER_IMAGE', 'coursewarehub/default-course-image:latest')
+c.Registry.host = registry_host
+c.Registry.username = os.environ.get('REGISTRY_USER', 'cwh')
+c.Registry.password = os.environ['REGISTRY_PASSWORD']
+

--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -181,11 +181,24 @@ c.JupyterHub.services = services
 debug_log = os.environ.get('DEBUG', '0') in ['yes', '1']
 
 ## Configure cwh_repo2docker spawner and service
+cwh_repo2docker_environ_names = [
+    'CONTAINER_IMAGE',
+    'REGISTRY_HOST',
+    'REGISTRY_USER',
+    'REGISTRY_PASSWORD'
+]
+
+service_environments = {}
+for name in cwh_repo2docker_environ_names:
+    if name in os.environ:
+        service_environments[name] = os.environ[name]
+
 cwh_repo2docker_config_path = '/srv/jupyterhub/cwh_repo2docker_config.py'
 cwh_repo2docker_jupyterhub_config(
     c,
     config_file=cwh_repo2docker_config_path,
     custom_menu=True,
+    service_environments=service_environments,
     debug=debug_log)
 load_subconfig(cwh_repo2docker_config_path)
 

--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -18,20 +18,12 @@ c.JupyterHub.hub_ip = '0.0.0.0'
 c.JupyterHub.ip = '0.0.0.0'
 
 ## Configure cwh_repo2docker spawner
-cwh_repo2docker_jupyterhub_config(c)
-
 registry_host = os.environ['REGISTRY_HOST']
 initial_image = os.environ.get('CONTAINER_IMAGE', 'coursewarehub/initial-course-image:latest')
 
 c.DockerSpawner.host_ip = "0.0.0.0"
 c.DockerSpawner.image = f'{registry_host}/{initial_image}'
 c.DockerSpawner.network_name = os.environ['BACKEND_NETWORK']
-
-c.Registry.initial_course_image = initial_image
-c.Registry.default_course_image = os.environ.get('CONTAINER_IMAGE', 'coursewarehub/default-course-image:latest')
-c.Registry.host = registry_host
-c.Registry.username = os.environ.get('REGISTRY_USER', 'cwh')
-c.Registry.password = os.environ['REGISTRY_PASSWORD']
 
 class CoursewareHubLogoutHandler(LogoutHandler):
     async def render_logout_page(self):
@@ -185,6 +177,11 @@ if cull_server == '1' or cull_server == 'yes':
             }
         )
 c.JupyterHub.services = services
+
+## Configure cwh_repo2docker spawner and service
+cwh_repo2docker_config_path = '/srv/jupyterhub/cwh_repo2docker_config.py'
+cwh_repo2docker_jupyterhub_config(c, cwh_repo2docker_config_path)
+load_subconfig(cwh_repo2docker_config_path)
 
 # debug log
 if os.environ.get('DEBUG', '0') in ['yes', '1']:

--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -178,16 +178,19 @@ if cull_server == '1' or cull_server == 'yes':
         )
 c.JupyterHub.services = services
 
+debug_log = os.environ.get('DEBUG', '0') in ['yes', '1']
+
 ## Configure cwh_repo2docker spawner and service
 cwh_repo2docker_config_path = '/srv/jupyterhub/cwh_repo2docker_config.py'
 cwh_repo2docker_jupyterhub_config(
     c,
     config_file=cwh_repo2docker_config_path,
-    custom_menu=True)
+    custom_menu=True,
+    debug=debug_log)
 load_subconfig(cwh_repo2docker_config_path)
 
 # debug log
-if os.environ.get('DEBUG', '0') in ['yes', '1']:
+if debug_log:
     c.JupyterHub.log_level = 'DEBUG'
     c.Spawner.debug = True
 

--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -180,7 +180,10 @@ c.JupyterHub.services = services
 
 ## Configure cwh_repo2docker spawner and service
 cwh_repo2docker_config_path = '/srv/jupyterhub/cwh_repo2docker_config.py'
-cwh_repo2docker_jupyterhub_config(c, cwh_repo2docker_config_path)
+cwh_repo2docker_jupyterhub_config(
+    c,
+    config_file=cwh_repo2docker_config_path,
+    custom_menu=True)
 load_subconfig(cwh_repo2docker_config_path)
 
 # debug log


### PR DESCRIPTION
- Switch to c.JupyterHub.services from deprecated c.JupyterHub.extra_handlers.
- Add check_allowed method to Repo2DockerSpawner to allow images in the registry.
  - The current docker spawner allows only configured images by default.
