### PR TITLE
Update the Cloud Gateway metadata URL

### DIFF
--- a/auth-proxy/resources/etc/templates/federation/module_metarefresh.php.j2
+++ b/auth-proxy/resources/etc/templates/federation/module_metarefresh.php.j2
@@ -22,7 +22,7 @@ $config = [
             'cron' => ['daily'],
             'sources' => [
                 [
-                    'src' => 'https://meatwiki.nii.ac.jp/confluence/download/attachments/6684843/cgidp-metadata.xml?api=v2'
+                    'src' => 'https://nii-auth.atlassian.net/wiki/download/attachments/44532011/cgidp-metadata.xml?api=v2',
                 ]
             ],
             'outputDir' => 'metadata/attributeauthority-remote/',


### PR DESCRIPTION
meatwiki.nii.ac.jp has been closed.